### PR TITLE
Add customer and product management pages

### DIFF
--- a/miniprogram/app.json
+++ b/miniprogram/app.json
@@ -3,6 +3,8 @@
     "pages/login/index",
     "pages/createOrder/index",
     "pages/orderList/index",
+    "pages/customerList/index",
+    "pages/productList/index",
     "pages/editOrder/index",
     "pages/orderDetail/index"
   ],

--- a/miniprogram/pages/customerList/index.js
+++ b/miniprogram/pages/customerList/index.js
@@ -1,0 +1,74 @@
+const { baseUrl } = require('../../utils/config')
+
+Page({
+  data: {
+    customers: [],
+    editId: null,
+    form: { name: '', email: '' }
+  },
+
+  onLoad() {
+    this.fetchCustomers()
+  },
+
+  fetchCustomers() {
+    wx.request({
+      url: `${baseUrl}/customers`,
+      success: res => {
+        this.setData({ customers: res.data })
+      }
+    })
+  },
+
+  startEdit(e) {
+    const id = e.currentTarget.dataset.id
+    const customer = this.data.customers.find(c => c.id === id)
+    if (customer) {
+      this.setData({ editId: id, form: { name: customer.name, email: customer.email } })
+    }
+  },
+
+  cancelEdit() {
+    this.setData({ editId: null, form: { name: '', email: '' } })
+  },
+
+  onName(e) {
+    this.setData({ 'form.name': e.detail.value })
+  },
+
+  onEmail(e) {
+    this.setData({ 'form.email': e.detail.value })
+  },
+
+  submitEdit() {
+    const { editId, form } = this.data
+    wx.request({
+      url: `${baseUrl}/customers/${editId}`,
+      method: 'PUT',
+      data: form,
+      success: () => {
+        this.setData({ editId: null, form: { name: '', email: '' } })
+        this.fetchCustomers()
+      }
+    })
+  },
+
+  deleteCustomer(e) {
+    const id = e.currentTarget.dataset.id
+    wx.showModal({
+      title: '删除确认',
+      content: '确定删除该客户吗？',
+      success: res => {
+        if (res.confirm) {
+          wx.request({
+            url: `${baseUrl}/customers/${id}`,
+            method: 'DELETE',
+            success: () => {
+              this.fetchCustomers()
+            }
+          })
+        }
+      }
+    })
+  }
+})

--- a/miniprogram/pages/customerList/index.wxml
+++ b/miniprogram/pages/customerList/index.wxml
@@ -1,0 +1,22 @@
+<view class="customer-list">
+  <block wx:for="{{customers}}" wx:key="id">
+    <view class="customer-item">
+      <view>
+        <view>名称：{{item.name}}</view>
+        <view>邮箱：{{item.email}}</view>
+      </view>
+      <view class="actions">
+        <button size="mini" data-id="{{item.id}}" bindtap="startEdit">编辑</button>
+        <button size="mini" type="warn" data-id="{{item.id}}" bindtap="deleteCustomer">删除</button>
+      </view>
+      <view wx:if="{{editId === item.id}}" class="edit-form">
+        <input type="text" value="{{form.name}}" bindinput="onName" placeholder="名称" />
+        <input type="text" value="{{form.email}}" bindinput="onEmail" placeholder="邮箱" />
+        <view class="edit-actions">
+          <button size="mini" bindtap="submitEdit" type="primary">保存</button>
+          <button size="mini" bindtap="cancelEdit">取消</button>
+        </view>
+      </view>
+    </view>
+  </block>
+</view>

--- a/miniprogram/pages/customerList/index.wxss
+++ b/miniprogram/pages/customerList/index.wxss
@@ -1,0 +1,21 @@
+.customer-list {
+  padding: 16rpx;
+}
+
+.customer-item {
+  margin-bottom: 16rpx;
+  border-bottom: 1px solid #eee;
+  padding-bottom: 8rpx;
+}
+
+.actions {
+  margin-top: 8rpx;
+}
+
+.edit-form {
+  margin-top: 8rpx;
+}
+
+.edit-actions {
+  margin-top: 8rpx;
+}

--- a/miniprogram/pages/productList/index.js
+++ b/miniprogram/pages/productList/index.js
@@ -1,0 +1,74 @@
+const { baseUrl } = require('../../utils/config')
+
+Page({
+  data: {
+    products: [],
+    editId: null,
+    form: { name: '', price: '' }
+  },
+
+  onLoad() {
+    this.fetchProducts()
+  },
+
+  fetchProducts() {
+    wx.request({
+      url: `${baseUrl}/products`,
+      success: res => {
+        this.setData({ products: res.data })
+      }
+    })
+  },
+
+  startEdit(e) {
+    const id = e.currentTarget.dataset.id
+    const product = this.data.products.find(p => p.id === id)
+    if (product) {
+      this.setData({ editId: id, form: { name: product.name, price: product.price } })
+    }
+  },
+
+  cancelEdit() {
+    this.setData({ editId: null, form: { name: '', price: '' } })
+  },
+
+  onName(e) {
+    this.setData({ 'form.name': e.detail.value })
+  },
+
+  onPrice(e) {
+    this.setData({ 'form.price': e.detail.value })
+  },
+
+  submitEdit() {
+    const { editId, form } = this.data
+    wx.request({
+      url: `${baseUrl}/products/${editId}`,
+      method: 'PUT',
+      data: form,
+      success: () => {
+        this.setData({ editId: null, form: { name: '', price: '' } })
+        this.fetchProducts()
+      }
+    })
+  },
+
+  deleteProduct(e) {
+    const id = e.currentTarget.dataset.id
+    wx.showModal({
+      title: '删除确认',
+      content: '确定删除该商品吗？',
+      success: res => {
+        if (res.confirm) {
+          wx.request({
+            url: `${baseUrl}/products/${id}`,
+            method: 'DELETE',
+            success: () => {
+              this.fetchProducts()
+            }
+          })
+        }
+      }
+    })
+  }
+})

--- a/miniprogram/pages/productList/index.wxml
+++ b/miniprogram/pages/productList/index.wxml
@@ -1,0 +1,22 @@
+<view class="product-list">
+  <block wx:for="{{products}}" wx:key="id">
+    <view class="product-item">
+      <view>
+        <view>名称：{{item.name}}</view>
+        <view>价格：{{item.price}}</view>
+      </view>
+      <view class="actions">
+        <button size="mini" data-id="{{item.id}}" bindtap="startEdit">编辑</button>
+        <button size="mini" type="warn" data-id="{{item.id}}" bindtap="deleteProduct">删除</button>
+      </view>
+      <view wx:if="{{editId === item.id}}" class="edit-form">
+        <input type="text" value="{{form.name}}" bindinput="onName" placeholder="名称" />
+        <input type="number" value="{{form.price}}" bindinput="onPrice" placeholder="价格" />
+        <view class="edit-actions">
+          <button size="mini" bindtap="submitEdit" type="primary">保存</button>
+          <button size="mini" bindtap="cancelEdit">取消</button>
+        </view>
+      </view>
+    </view>
+  </block>
+</view>

--- a/miniprogram/pages/productList/index.wxss
+++ b/miniprogram/pages/productList/index.wxss
@@ -1,0 +1,21 @@
+.product-list {
+  padding: 16rpx;
+}
+
+.product-item {
+  margin-bottom: 16rpx;
+  border-bottom: 1px solid #eee;
+  padding-bottom: 8rpx;
+}
+
+.actions {
+  margin-top: 8rpx;
+}
+
+.edit-form {
+  margin-top: 8rpx;
+}
+
+.edit-actions {
+  margin-top: 8rpx;
+}


### PR DESCRIPTION
## Summary
- create `customerList` and `productList` pages
- support listing, editing and deleting customers/products
- register both pages in `app.json`

## Testing
- `npm test` *(fails: Invalid package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6847f99ac97083319aaf761ea16597cc